### PR TITLE
Update winshock_test.sh

### DIFF
--- a/winshock_test.sh
+++ b/winshock_test.sh
@@ -93,7 +93,7 @@ if [[ "$patched" == "yes" ]]
 then
   patched="\033[92mYES\033[39m"
 else
-  patched="\033[91mNO\033[39m"
+  patched="\033[91mDONTKNOW\033[39m"
 fi
 
 echo -e "System at $SERVER seems to be patched: $patched"


### PR DESCRIPTION
you can't claim it has not been patched because it did not support the cipher strings! These can be disabled. Take a look at www.bettercrypto.org --> IIS section or https://www.nartac.com/Products/IISCrypto/
